### PR TITLE
Allow multilingual keys to use underscores.

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -82,10 +82,12 @@ function string( path ) {
 }
 
 export
-function multilingual( path, valueParser, group = false, languages = null ) {
+function multilingual( path, valueParser, group = false, parseType = null, languages = null ) {
     // const originalPath = _.isFunction(path) ? path.path : path;
     const parser = group ? parsers.groupingMultilingual : parsers.multilingual;
     const reverser = group ? reversers.groupingMultilingual : reversers.multilingual;
+
+    parseType = parseType || multilingual.TYPE_DEFAULT || multilingual.CAMELCASE;
 
     // We go up one in the hierarchy such that `reverse` can set the
     // language properties on the parent.
@@ -98,10 +100,13 @@ function multilingual( path, valueParser, group = false, languages = null ) {
         key = key.split('.').pop();
 
     const lang = languages || multilingual.AVAILABLE_LANGUAGES;
-    const f = createParser( prefix, parser, key, valueParser, lang );
-    f.reverse = createReverse(prefix, reverser, key, lang);
+    const f = createParser( prefix, parser, key, valueParser, parseType, lang );
+    f.reverse = createReverse(prefix, reverser, key, parseType, lang);
     return f;
 }
+
+multilingual.TYPE_CAMELCASE = 'camelCase';
+multilingual.TYPE_UNDERSCORE = 'underscore';
 
 multilingual.AVAILABLE_LANGUAGES = [ 'en', 'nl', 'fr' ];
 

--- a/src/reversers.js
+++ b/src/reversers.js
@@ -3,16 +3,21 @@
 import _ from 'lodash';
 import { ucfirst } from './utils';
 
+const CAMELCASE = 'camelCase';
+const prefixUnderscore = ( x => '_' + x );
+
 export
-function multilingual( path, data, name ) {
+function multilingual( path, data, name, parseType = CAMELCASE ) {
+    const languageTransform = ( parseType == CAMELCASE ) ? ucfirst : prefixUnderscore;
     return _.transform(data, (output, value, lang) => {
-        const key = name + ucfirst(lang);
+        const key = name + languageTransform(lang);
         output[key] = value;
     }, {});
 }
 
 export
-function groupingMultilingual( path, data, name = null, languages = [] ) {
+function groupingMultilingual( path, data, name = null, parseType = CAMELCASE, languages = [] ) {
+    const languageTransform = ( parseType == CAMELCASE ) ? ucfirst : prefixUnderscore;
     return _.transform(data, (output, values, key) => {
         if( !_.isObject(values) || _.difference(_.keys(values), languages).length > 0 ) {
             output[key] = values;
@@ -20,7 +25,7 @@ function groupingMultilingual( path, data, name = null, languages = [] ) {
         }
 
         _.each(values, (value, lang) => {
-            output[key + ucfirst(lang)] = value;
+            output[key + languageTransform(lang)] = value;
         });
     }, {});
 }

--- a/test/parse.js
+++ b/test/parse.js
@@ -232,6 +232,18 @@ describe('parse.js', function() {
             }, 'Language values should be compacted into an array');
         });
 
+        it('Should read an array for multilingual fields using an underscore', function() {
+            assert.deepEqual(parse.multilingual('key', x => x, false, 'underscore')({
+                key_nl: 'een test',
+                key_fr: 'une test',
+                key_en: 'a test'
+            }), {
+                nl: 'een test',
+                fr: 'une test',
+                en: 'a test'
+            }, 'Language values should be compacted into an array');
+        });
+
         it('Should be able to parse multilingual values', function() {
             assert.deepEqual(parse.multilingual('key', valueParser)(subject), {
                 nl: 'EEN TEST',
@@ -259,6 +271,22 @@ describe('parse.js', function() {
             };
 
             assert.deepEqual(parser.reverse(data), subject, 'Reverse should match subject');
+        });
+
+
+        it('Should be able to reverse multilingual properties with underscores', function() {
+            var parser = parse.multilingual('key', x => x, false, 'underscore');
+            var data = {
+                nl: 'een test',
+                fr: 'une test',
+                en: 'a test'
+            };
+
+            assert.deepEqual(parser.reverse(data), {
+                key_nl: 'een test',
+                key_fr: 'une test',
+                key_en: 'a test'
+            }, 'Reverse should match subject');
         });
 
         it('Should be able to reverse nested multilingual properties', function() {


### PR DESCRIPTION
Resolves https://github.com/bubobox/parse-js/issues/4
