### PR TITLE
Nested reverse fix

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -18,6 +18,7 @@ export
 function createParser( path, parser, ...args ) {
     const p = data => parse( path, parser, data, ...args );
     p.path = path;
+    p.nestsResult = parser.nestsResult || false;
     return p;
 }
 

--- a/src/parse.js
+++ b/src/parse.js
@@ -27,7 +27,7 @@ function parse( path, parser, data, ...args ) {
     if( !_.isFunction(parser) )
         throw new Error('Invalid parser supplied to parse()');
 
-    // If path is a function and result is a function we might
+    // If path is a function and result is an object we might
     // be dealing with a nested spec.
     if( parser.requiresScalarInput && _.isFunction(path) && _.isPlainObject(result) )
         return _.transform(result, ( r, v, k ) => r[k] = parser(v, ...args), {});
@@ -43,12 +43,20 @@ function parse( path, parser, data, ...args ) {
  */
 export
 function reverse( path, reverser, data, ...args ) {
-    const reversed = reverser( path, data, ...args );
 
     // If path is a function we might find a function that
     // controls how this value should be reversed.
-    if( _.isFunction(path) && _.isFunction(path.reverse) )
-        return path.reverse( reversed );
+    if( _.isFunction(path) && _.isFunction(path.reverse) ) {
+
+        if (path.nestsResult)
+            data = _.transform(data, ( r, v, k ) => r[k] = reverser( null, v, ...args), {});
+        else
+            data = reverser( null, data, ...args );
+
+        return path.reverse(data);
+    }
+
+    const reversed = reverser( path, data, ...args );
 
     // Only functions/strings are valid paths, so throw an error
     // if this is not a string.
@@ -67,4 +75,3 @@ function reverse( path, reverser, data, ...args ) {
 
     return result;
 }
-

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -114,6 +114,7 @@ function multilingual(data, path, valueParser = (x => x), parseType = CAMELCASE,
     });
     return values;
 }
+multilingual.nestsResult = true;
 
 /**
  * Group keys that have language suffixes as their respective prefix.
@@ -144,6 +145,7 @@ function groupingMultilingual(data, path, valueParser = (x => x), parseType = CA
 
     return values;
 }
+multilingual.nestsResult = true;
 
 /**
  * Only select keys that have a match with `match`.

--- a/src/reversers.js
+++ b/src/reversers.js
@@ -65,9 +65,6 @@ function number(value, NaNValue = 0) {
 
 export
 function base64(path, value) {
-    if( _.isPlainObject(value) )
-        return _.transform(value, (r, v, k) => r[k] = base64(null, v), {});
-
     return Base64.encode(value);
 }
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -443,6 +443,10 @@ describe('parse.js', function() {
                 },
                 test6: {
                     settingAnswers: Base64.encode(html)
+                },
+                test7: {
+                    fooNl: JSON.stringify({ winning: '9999', times: '!' }),
+                    fooEn: JSON.stringify({ winning: '1111', times: '!' })
                 }
             };
 
@@ -541,6 +545,26 @@ describe('parse.js', function() {
             };
 
             assert.deepEqual(parser.reverse({ nl: 'lorem ipsum <iframe>html code</iframe>' }), target, 'Should reverse base64 in multilingual fields');
+        });
+
+        it('Should parse json in multilingual fields', function() {
+            var parser = parse.json(parse.multilingual('test7.foo'));
+            var target = {
+                nl: { winning: '9999', times: '!' },
+                en: { winning: '1111', times: '!' }
+            };
+
+            assert.deepEqual(parser(subject), target, 'Should parse json in multilingual fields');
+        });
+
+        it('Should reverse json in multilinual fields', function() {
+            var parser = parse.json(parse.multilingual('test7.foo'));
+            var target = {
+                nl: { winning: '9999', times: '!' },
+                en: { winning: '1111', times: '!' }
+            };
+
+            assert.deepEqual(parser.reverse(target), _.pick(subject, 'test7'), 'Should reverse base64 in multilingual fields');
         });
     });
 


### PR DESCRIPTION
Nested reversing wasn't working in all cases with multilanguage parser, this should fix that by making multilanguage state explicitly that it nests its resulting value so this can be taken into account during the reversing process.

Resolves #12 
