### PR TITLE
[spec] Transform strings in spec to parse instances.

### DIFF
--- a/src/transformers/spec.js
+++ b/src/transformers/spec.js
@@ -1,14 +1,26 @@
 const _isPlainObject = require('lodash/isPlainObject');
 const _transform = require('lodash/transform');
 const _merge = require('lodash/merge');
+const parse = require('../parse');
 
 function SpecTransformer(spec) {
     if( !(this instanceof SpecTransformer) ) {
         return this.transform(new SpecTransformer(spec));
     }
 
-    this._spec = spec;
+    this._spec = this._completeSpec(spec);
 }
+
+SpecTransformer.prototype._completeSpec = function(spec) {
+    return _transform(spec, (r, v, k) => {
+        if (typeof v === 'string')
+            v = parse(v);
+        else if (_isPlainObject(v))
+            v = this._completeSpec(v);
+
+        r[k] = v;
+    }, {});
+};
 
 SpecTransformer.prototype.parse = function(source) {
     return this._toSpec(this._spec, source);

--- a/test/transformers/spec.js
+++ b/test/transformers/spec.js
@@ -16,16 +16,41 @@ describe('spec', function() {
 
     describe('#constructor', function() {
         it('Should create an instance without new keyword when attached', function() {
-            const spec = { 'some': 'key' };
+            const spec = { 'some': new Parse('value', 'reverse') };
             const obj = {
                 spec: Spec,
                 transform: instance => {
                     assert(instance instanceof Spec);
-                    assert.equal(instance._spec, spec);
+                    assert.deepEqual(instance._spec, spec);
                 }
             };
 
             obj.spec(spec);
+        })
+
+        it('Should convert strings to parse().select() parsers.', function() {
+            const parser = new Parse('parse', 'reverse');
+            const instance = new Spec({
+                key: 'test',
+                some: parser,
+                value: {
+                    a: 'a'
+                }
+            });
+
+            const spec = instance._spec;
+
+            assert.equal(typeof spec.key, 'object');
+            assert.equal(typeof spec.key.parse, 'function');
+            assert.equal(typeof spec.key.reverse, 'function');
+
+            assert.equal(typeof spec.value, 'object');
+            assert.equal(typeof spec.value.a, 'object');
+            assert.equal(typeof spec.value.a.parse, 'function');
+            assert.equal(typeof spec.value.a.reverse, 'function');
+
+            assert.ok(spec.some instanceof Parse);
+            assert.equal(spec.some, parser);
         })
     })
 


### PR DESCRIPTION
This simplifies basic specs.
