### PR TITLE
[array] On invalid input return empty array.

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ The selected value will be concatenated with an empty string which will call the
 parse().array([options = {}])
 ```
 
-This transformer will ensure that the selected value will be converted to an array. Whenever this fails it will set `null`.
+This transformer will ensure that the selected value will be converted to an array. Whenever this fails it will return an empty array.
 
 - `options`
   - `mode` the methods that are allowed to be used to convert values to arrays. (default: `ANY`). Valid options are `ANY`, `JSON` and `SEPARATOR`.

--- a/src/transformers/array.js
+++ b/src/transformers/array.js
@@ -36,6 +36,9 @@ ArrayTransformer.prototype.parse = function(value) {
     if (this._mode === MODE_SEPARATOR || (this._mode === MODE_ANY && !result))
         result = value.split(this._separator);
 
+    if (!isArray(result))
+        result = [];
+
     return result;
 };
 

--- a/test/transformers/array.js
+++ b/test/transformers/array.js
@@ -77,7 +77,7 @@ describe('array', function() {
             });
             const result = instance.parse('1,2,4,5');
 
-            assert.deepEqual(result, null);
+            assert.deepEqual(result, []);
         })
 
         it('Should cast non-string values', function() {


### PR DESCRIPTION
The result of the array transform should always be an array.
