### PR TITLE
[base64] Switch to compact-base64

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/bubobox/parse-js#readme",
   "dependencies": {
-    "js-base64": "^2.1.9",
+    "compact-base64": "^1.1.0",
     "lodash": "^4.10.0"
   },
   "devDependencies": {

--- a/src/lib/base64.js
+++ b/src/lib/base64.js
@@ -1,4 +1,4 @@
-const { Base64 } = require('js-base64');
+const Base64 = require('compact-base64');
 
 const _rBase64 = /^[ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/]+=*$/;
 const _rNonPrintable = /[\x00-\x08\x0E-\x1F\x7F\x80-\x9F]/;

--- a/test/lib/base64.js
+++ b/test/lib/base64.js
@@ -57,4 +57,10 @@ describe('lib/base64', function() {
             assert(!Base64.isBase64Printable(new Date()), 'No valid strings');
         })
     })
+
+    describe('#encode', function() {
+        it('Should decode UTF-8 correctly', function() {
+            assert(Base64.encode('💩'), '8J+SqQ==');
+        })
+    })
 });

--- a/test/lib/json.js
+++ b/test/lib/json.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 
-describe('lib/base64', function() {
+describe('lib/json', function() {
     let JSONLib = null;
 
     before(function() {


### PR DESCRIPTION
The issue with unicode characters has been resolved.
https://github.com/ambassify/compact-base64-js/issues/1
