### PR TITLE
fix(map): map should not mess with object keys

### DIFF
--- a/src/transformers/map.js
+++ b/src/transformers/map.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const _transform = require('../lib/transform');
-const _merge = require('lodash/merge');
 const _isArray = require('lodash/isArray');
 
 function MapTransformer(callback, parse) {
@@ -18,9 +17,8 @@ MapTransformer.prototype._createParse = function(key) {
     const parse = this._parse;
     const cache = this._cache;
 
-    if (!(key in cache)) {
-        cache[key] = this._callback(parse().select(key));
-    }
+    if (!(key in cache))
+        cache[key] = this._callback(parse());
 
     return cache[key];
 };
@@ -28,7 +26,7 @@ MapTransformer.prototype._createParse = function(key) {
 MapTransformer.prototype.parse = function(source, instance, root) {
     const accumulator = _isArray(source) ? [] : {};
     return _transform(source, (result, value, key) => {
-        result[key] = this._createParse(key).parse(source, instance, root);
+        result[key] = this._createParse(key).parse(value, instance, root);
     }, accumulator);
 };
 
@@ -36,11 +34,7 @@ MapTransformer.prototype.reverse = function(source, instance, root) {
     const isArray = _isArray(source);
     const accumulator = isArray ? [] : {};
     return _transform(source, (result, value, key) => {
-        const reverse = this._createParse(key).reverse(source[key], instance, root);
-        if (isArray)
-            result[key] = reverse[key];
-        else
-            _merge(result, reverse);
+        result[key] = this._createParse(key).reverse(value, instance, root);
     }, accumulator);
 };
 

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -5,6 +5,7 @@
         "mocha": true
     },
     "rules": {
-        "semi": 0
+        "semi": 0,
+        "strict": 0
     }
 }

--- a/test/transformers/map.js
+++ b/test/transformers/map.js
@@ -12,6 +12,8 @@ describe('map', function() {
 
     describe('#constructor', function() {
         it('Should create an instance without new keyword when attached', function() {
+            const callback = function() {};
+
             const obj = {
                 map: Map,
                 transform: instance => {
@@ -20,7 +22,6 @@ describe('map', function() {
                 }
             };
 
-            const callback = function() {};
             obj.map(callback);
         })
     })
@@ -66,13 +67,9 @@ describe('map', function() {
         })
 
         it('Should parse an array correctly', function() {
-            const callback = function(p) {
-                assert(p instanceof Parse);
-                assert(p._chain[0]);
-                assert.notEqual(typeof p._chain[0]._path, 'undefined');
-
+            const callback = function() {
                 return {
-                    parse: (v) => '_' + v[p._chain[0]._path]
+                    parse: (v) => '_' + v
                 };
             }
             const instance = new Map(callback);
@@ -107,24 +104,43 @@ describe('map', function() {
             const callback = function(p) {
                 assert(p instanceof Parse);
                 return {
-                    reverse: (v) => ({ test1: v })
+                    reverse: () => 'abcd'
                 };
             }
             const instance = new Map(callback);
             const result = instance.reverse({ test1: 'test', test2: 'abcd' });
 
-            assert.deepEqual(result, { test1: 'abcd' });
+            assert.deepEqual(result, { test1: 'abcd', test2: 'abcd' });
+        })
+
+        it('Should reverse an object with dots in keys correctly', function() {
+            const callback = function(p) {
+                assert(p instanceof Parse);
+
+                return {
+                    reverse: (v) => '_' + v
+                };
+            }
+
+            const instance = new Map(callback);
+
+            const result = instance.reverse({
+                test1: 'test',
+                'test1.subTest': 'subTest'
+            });
+
+            assert.deepEqual(result, {
+                test1: '_test',
+                'test1.subTest': '_subTest'
+            });
         })
 
         it('Should detect object or array', function() {
             const callback = function(p) {
                 assert(p instanceof Parse);
-                assert(p._chain[0]);
-                assert.notEqual(typeof p._chain[0]._path, 'undefined');
 
-                const id = p._chain[0]._path;
                 return {
-                    reverse: (v) => ({ [id]: '_' + v })
+                    reverse: (v) => '_' + v
                 };
             }
             const instance = new Map(callback);

--- a/test/transformers/map.js
+++ b/test/transformers/map.js
@@ -67,7 +67,8 @@ describe('map', function() {
         })
 
         it('Should parse an array correctly', function() {
-            const callback = function() {
+            const callback = function(p) {
+                assert(p instanceof Parse);
                 return {
                     parse: (v) => '_' + v
                 };


### PR DESCRIPTION
It is a breaking change in that previously it was possible to forgo the default parser passed to your map callback to remap the keys as well. I'm not sure if that's something that's actually expected?

Regular usage as I've always seen it:

```js
const parser = parse().map(p => p.string());
const result = parser.parse({ foo: 1 });
// { foo: "1" }
```

Where the string transformer only works on the object values and depends on the existing "p" to pre-select the key. My pull requests moves the preselecting part elsewhere to make sure "parse.select" isn't used because that messes with the keys on reverse as it interprets keys as lodash paths.

On the other hand, before my PR, this was also possible

```js
const parser = parse().map(() => parse('foo').number());

console.log(parser.parse({
    foo: '1',
    bar: '2',
}));
// { foo: 1, bar: 1 }

console.log(parser.reverse({
    foo: 1,
    bar: 2,
}));
// { foo: 2 }
```

So you could access the entire "source" object in the parser and return a value not based on the previous key but your reverser would just be broken so unless I'm missing something this isn't how map is supposed to be used?